### PR TITLE
spec: Requires clamd instead of clamav-server

### DIFF
--- a/nethserver-antivirus.spec
+++ b/nethserver-antivirus.spec
@@ -8,7 +8,7 @@ Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
 
 Requires: nethserver-base
-Requires: clamav-server, clamav-server-systemd
+Requires: clamd
 Requires: clamav-unofficial-sigs
 
 BuildRequires: nethserver-devtools


### PR DESCRIPTION
clamav-0.100.0-2 changed clamav-server to clamd and suggests removing clamav-server-systemd.

```
# rpm -qi clamav-server-systemd-0.100.0-2.el7.x86_64
Name        : clamav-server-systemd
Version     : 0.100.0
Release     : 2.el7
Architecture: x86_64
Install Date: Wed 11 Jul 2018 04:30:21 AM CEST
Group       : Applications/File
Size        : 0
License     : GPLv2
Signature   : RSA/SHA256, Sun 03 Jun 2018 04:05:38 PM CEST, Key ID 6a2faea2352c64e5
Source RPM  : clamav-0.100.0-2.el7.src.rpm
Build Date  : Sun 03 Jun 2018 03:27:06 PM CEST
Build Host  : buildvm-05.phx2.fedoraproject.org
Relocations : (not relocatable)
Packager    : Fedora Project
Vendor      : Fedora Project
URL         : https://www.clamav.net/
Bug URL     : https://bugz.fedoraproject.org/clamav
Summary     : Systemd initscripts for clamav server
Description :
Empty package just to allow migration of service without stop it and disable it
(#1583599). you may remove this package now (dnf remove clamav-server-systemd).
```