### PR TITLE
Add template fragment and file permission

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -40,13 +40,9 @@ event_actions('nethserver-antivirus-update',
 	      'nethserver-antivirus-init-avdb' => '30');
 
 #
-# proxy-modify event and action
+# proxy-modify event template
 #
 
 event_templates('proxy-modify', qw(
     /etc/freshclam.conf
-));
-
-event_actions('proxy-modify', qw(
-    nethserver-antivirus-init-avdb 30
 ));

--- a/createlinks
+++ b/createlinks
@@ -38,3 +38,15 @@ event_templates('nethserver-antivirus-update', @templates);
 event_actions('nethserver-antivirus-update',
 	      'initialize-default-databases' => '00',
 	      'nethserver-antivirus-init-avdb' => '30');
+
+#
+# proxy-modify event and action
+#
+
+event_templates('proxy-modify', qw(
+    /etc/freshclam.conf
+));
+
+event_actions('proxy-modify', qw(
+    nethserver-antivirus-init-avdb 30
+));

--- a/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
+++ b/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
@@ -22,9 +22,6 @@
 db_dir=/var/lib/clamav
 eicar_db=${db_dir}/eicar.ndb
 
-# set safe permission for config file because of proxy password
-chmod 600 /etc/freshclam.conf
-
 # Early exit if eicar.ndb is already present
 [ -e $eicar_db ] && exit 0
 # Ensure Eicar signature is present, at least:

--- a/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
+++ b/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
@@ -22,6 +22,9 @@
 db_dir=/var/lib/clamav
 eicar_db=${db_dir}/eicar.ndb
 
+# set safe permission for config file because of proxy password
+chmod 600 /etc/freshclam.conf
+
 # Early exit if eicar.ndb is already present
 [ -e $eicar_db ] && exit 0
 # Ensure Eicar signature is present, at least:

--- a/root/etc/e-smith/templates.metadata/etc/freshclam.conf
+++ b/root/etc/e-smith/templates.metadata/etc/freshclam.conf
@@ -1,0 +1,3 @@
+UID="root"
+GID="root"
+PERMS="0600"

--- a/root/etc/e-smith/templates/etc/freshclam.conf/20proxy
+++ b/root/etc/e-smith/templates/etc/freshclam.conf/20proxy
@@ -1,0 +1,26 @@
+{
+my $host = $proxy{host};
+my $port = $proxy{port} || "3128";
+my $user = $proxy{user};
+my $password = $proxy{password};
+if ($host ne "") {
+
+$OUT .=<<"EOF";
+#
+# 20proxy - proxy settings
+#
+HTTPProxyServer $host
+HTTPProxyPort $port
+EOF
+
+  if ($user ne "" and $password ne "") {
+
+$OUT .=<<"EOF";
+HTTPProxyUsername $user
+HTTPProxyPassword $password
+EOF
+
+  }
+}
+
+}


### PR DESCRIPTION
Added a template fragment for respecting proxy settings in /etc/freshclam.conf. 
Added "chmod 600 /etc/freshclam" to the "nethserver-antivirus-init-avdb" action because freshclam does not start when permissions are more than 700 and HTTPProxyPassword is used.
The "proxy-modify" event again triggers the template recreation and the "nethserver-antivirus-init-avdb" action to set permissions to ensure freshclam starts downloading.

NethServer/dev#5727