### PR TITLE
unofficial sigs: reload all clamd instances

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
+++ b/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
@@ -36,5 +36,8 @@ if [ "$officialsig" == "disabled" ]; then
     rm -f /var/lib/clamav/{bytecode.???,daily.???,main.???}
 fi
 
+# Remove old unused clamav-unofficial-sigs config file
+rm -f /etc/clamav-unofficial-sigs/clamav-unofficial-sigs.conf
+
 # Restart all clamd instances
 systemctl try-restart clamd@*

--- a/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
+++ b/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
@@ -35,3 +35,6 @@ officialsig=$(/sbin/e-smith/config getprop clamd OfficialSignatures)
 if [ "$officialsig" == "disabled" ]; then
     rm -f /var/lib/clamav/{bytecode.???,daily.???,main.???}
 fi
+
+# Restart all clamd instances
+systemctl try-restart clamd@*

--- a/root/etc/e-smith/templates/etc/clamav-unofficial-sigs/user.conf/10base
+++ b/root/etc/e-smith/templates/etc/clamav-unofficial-sigs/user.conf/10base
@@ -21,6 +21,7 @@
 # Please note, it is your responsibility to manage the contents of this file.
 # Values provided here are just examples, feel free to use any values from the main config file.
 
-# NethServer: restart all clamd instances
-clamd_reload_opt="systemctl try-restart clamd@*"
+# NethServer: reload and restart all clamd instances
+clamd_reload_opt="systemctl reload clamd@*"
+clamd_restart_opt="systemctl try-restart clamd@*"
 

--- a/root/etc/e-smith/templates/etc/clamav-unofficial-sigs/user.conf/10base
+++ b/root/etc/e-smith/templates/etc/clamav-unofficial-sigs/user.conf/10base
@@ -21,3 +21,6 @@
 # Please note, it is your responsibility to manage the contents of this file.
 # Values provided here are just examples, feel free to use any values from the main config file.
 
+# NethServer: restart all clamd instances
+clamd_reload_opt="systemctl try-restart clamd@*"
+

--- a/root/etc/systemd/system/clamd@.service.d/reload.conf
+++ b/root/etc/systemd/system/clamd@.service.d/reload.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecReload=/usr/bin/clamdscan --config-file=/etc/clamd.d/%i.conf --reload


### PR DESCRIPTION
- The default configuration of clamav-unofficial-sigs only restarts `clamd@scan` instance which is not used by NethServer
- All clamd instances are now restarted by nethserver-antivirus event and reloaded by `/etc/clamav-unofficial-sigs/user.conf`

NethServer/dev#5803