### PR TITLE
Disable official signatures by default

### DIFF
--- a/root/etc/e-smith/db/configuration/defaults/clamd/OfficialSignatures
+++ b/root/etc/e-smith/db/configuration/defaults/clamd/OfficialSignatures
@@ -1,1 +1,1 @@
-enabled
+disabled


### PR DESCRIPTION
Official signatures are mostly useless and eat a lot of ram.

NethServer/dev#5831