### PR TITLE
HACK: disable mail from unofficial-sigs

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
+++ b/root/etc/e-smith/events/actions/nethserver-antivirus-init-avdb
@@ -41,3 +41,6 @@ rm -f /etc/clamav-unofficial-sigs/clamav-unofficial-sigs.conf
 
 # Restart all clamd instances
 systemctl try-restart clamd@*
+
+# Temporary fix for https://bugzilla.redhat.com/show_bug.cgi?id=1794506
+sed -i  's/MAILTO=root/MAILTO=/' /etc/cron.d/clamav-unofficial-sigs


### PR DESCRIPTION
Temporary suppress useless noise, see upstream issues:
- https://bugzilla.redhat.com/show_bug.cgi?id=1794506
- https://github.com/extremeshok/clamav-unofficial-sigs/issues/281

Before merge, maybe it's better to open a new issue.