### PR TITLE
Obsoletes clamav-data

### DIFF
--- a/nethserver-antivirus.spec
+++ b/nethserver-antivirus.spec
@@ -11,6 +11,7 @@ BuildArch: noarch
 Requires: nethserver-base
 Requires: clamd
 Requires: clamav-unofficial-sigs
+Obsoletes: clamav-data
 
 BuildRequires: nethserver-devtools
 


### PR DESCRIPTION
On old installations, where clamav-data is present, yum updates
reinstall official signatures (main.cvd,daily.cvd,bytecode.cvd)
even if the prop OfficialSignatures is set to disabled.

By removing the clamav-data package, all installations
will no longer receive updates on OfficialSignatures.

NethServer/dev#6113